### PR TITLE
Use classes to determine image ids

### DIFF
--- a/libs/htmlpurifier-html5/library/HTMLPurifier/HTML5Definition.php
+++ b/libs/htmlpurifier-html5/library/HTMLPurifier/HTML5Definition.php
@@ -105,6 +105,7 @@ class HTMLPurifier_HTML5Definition
         // IMG
         $def->addAttribute('img', 'srcset', 'Text');
         $def->addAttribute('img', 'sizes', 'Text');
+        $def->addAttribute('img', 'data-attachment-id', 'Text');
 
         // IFRAME
         $def->addAttribute('iframe', 'allowfullscreen', 'Bool');

--- a/libs/purifier.php
+++ b/libs/purifier.php
@@ -5,18 +5,18 @@ function load_purifier() {
   require_once(plugin_dir_path(__FILE__) . '/htmlpurifier-html5/autoload.php');
   
   $config = HTMLPurifier_HTML5Config::createDefault();
-
+  
   $upload = wp_upload_dir();
   $htmlpurifier_dir = $upload['basedir'] . DS . 'frontity' . DS . 'htmlpurifier';
-
+  
   if (is_dir($htmlpurifier_dir)) {
     $config->set('Cache', 'SerializerPath', $htmlpurifier_dir);
-	} else {
+  } else {
     $config->set('Core', 'DefinitionCache', null);
   }
 
   $config->set('HTML.Doctype', 'HTML 4.01 Transitional');
-
+    
   // Rule: All the CSS rules allowed.
   $config->set('CSS.AllowTricky', true);
 
@@ -38,6 +38,10 @@ function load_purifier() {
   $config->set('AutoFormat', 'RemoveEmpty', true);
   $config->set('AutoFormat', 'RemoveEmpty.RemoveNbsp', true);
   $config->set('AutoFormat', 'AutoParagraph', true);
+
+  // IMG Attributes
+  // This is defined in HTML5Definitions.php line 108 (DON'T OVERWRITE IT!!)
+  // $def->addAttribute('img', 'data-attachment-id', 'Text');
 
   return new HTMLPurifier($config);
 }

--- a/wp-pwa.php
+++ b/wp-pwa.php
@@ -259,12 +259,12 @@ class wp_pwa
 			if ($dataAttachmentId) {
 				$imgIds[] = intval($dataAttachmentId);
 			} elseif ($wpImage && isset($wpImage[1])) {
-				$image->setAttribute('data-attachment-id-class', $wpImage[1]);
+				$image->setAttribute('data-attachment-id', $wpImage[1]);
 				$imgIds[] = intval($wpImage[1]);
 			} else {
 				$id = $this->get_attachment_id($image->src);
 				if ($id !== 0) {
-					$image->setAttribute('data-attachment-id-db', $id);
+					$image->setAttribute('data-attachment-id', $id);
 					$imgIds[] = intval($id);
 				}
 			}

--- a/wp-pwa.php
+++ b/wp-pwa.php
@@ -71,8 +71,25 @@ class wp_pwa
 		add_action('registered_post_type', array($this, 'add_custom_post_types_filters'));
 
 		add_action('wp_head', array($this,'amp_add_canonical'));
+
+		add_filter('wp_get_attachment_link', array( $this, 'add_id_to_gallery_images'), 10, 2);
 	}
 
+	function add_id_to_gallery_images($html, $attachment_id) {
+		// var_dump($html);
+		$attachment_id = intval($attachment_id);
+		$html = str_replace(
+			'<img ',
+			sprintf(
+				'<img data-attachment-id="%1$d" ',
+				$attachment_id
+			),
+			$html
+		);
+		$html = apply_filters('jp_carousel_add_data_to_images', $html, $attachment_id);
+		return $html;
+	}
+	
 	function add_custom_post_types_filters($post_type) {
 		add_filter('rest_prepare_' . $post_type, array($this, 'purify_html'), 9);
 		add_filter('rest_prepare_' . $post_type, array($this, 'add_latest_to_links'), 10);


### PR DESCRIPTION
Get ids from `wp_get_attachment_link` wp function or `wp-image-xx` classes.

Fixes https://github.com/frontity/wp-plugin/issues/18