### PR TITLE
Option to filter api fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [1.5.1](https://github.com/frontity/wp-plugin/compare/v1.5.0...v1.5.1) (2018-09-11)
+
+
+### Bug Fixes
+
+* **version:** update version in php files and use trunk ([150ddf6](https://github.com/frontity/wp-plugin/commit/150ddf6))
+
 # [1.5.0](https://github.com/frontity/wp-plugin/compare/v1.4.15...v1.5.0) (2018-09-11)
 
 

--- a/admin/js/wp-pwa-admin.js
+++ b/admin/js/wp-pwa-admin.js
@@ -52,10 +52,22 @@ jQuery(document).on('ready', function () {
       jQuery('#lateral-excludes').toggle();
     });
 
+    jQuery('.open-api-fields').on('click', function (e) {
+      e.preventDefault();
+      e.stopPropagation();
+      jQuery('#lateral-api-fields').toggle();
+    });
+
     jQuery('.close-excludes').on('click', function(e) {
       e.preventDefault();
       e.stopPropagation();
       jQuery('#lateral-excludes').hide();
+    });
+
+    jQuery('.close-api-fields').on('click', function(e) {
+      e.preventDefault();
+      e.stopPropagation();
+      jQuery('#lateral-api-fields').hide();
     });
 
     jQuery('.open-advanced-settings').on('click', function (e) {
@@ -290,6 +302,34 @@ jQuery(document).on('ready', function () {
             jQuery('#save-excludes').removeClass('is-loading');
             jQuery('#lateral-excludes').hide();
 
+          }
+        },
+        error: function (response) {
+          console.log("ERROR: Excludes couldn't be saved");
+          jQuery('#save-excludes').removeClass('is-loading');
+        }
+      });
+    });
+
+    jQuery('#save-api-fields').on('click', function(e) {
+      jQuery('#save-api-fields').addClass('is-loading');
+      e.preventDefault();
+      e.stopPropagation();
+
+      var apiFields = jQuery('textarea#api-fields').val();
+      apiFields = apiFields.split('\n').filter(url => !/^\s*$/.test(url)).join('\n');
+
+      jQuery.ajax({
+        url: ajaxurl,
+        method: "POST",
+        data: {
+            action: 'wp_pwa_save_api_fields',
+            wp_pwa_api_fields: apiFields
+        },
+        success: function (response) {
+          if (response.hasOwnProperty('status') && response.status == 'ok' ) {
+            jQuery('#save-api-fields').removeClass('is-loading');
+            jQuery('#lateral-api-fields').hide();
           }
         },
         error: function (response) {

--- a/admin/wp-pwa-admin-page.php
+++ b/admin/wp-pwa-admin-page.php
@@ -313,6 +313,8 @@
 				<div id="wp-pwa-advanced-settings-lateral" style="text-align: right;" <?php echo ($synced_with_wp_pwa?'':'style="display:none;"');?>>
 					<p>
 						<hr>
+						<a class="open-api-fields" href="#" style="font-size: 10px; text-decoration: underline;">WP API Fields</a>
+						<span style="font-size: 10px; margin: 0 5px 0 5px;"> </span>
 						<a class="open-excludes" href="#" style="font-size: 10px; text-decoration: underline;">PWA Excludes</a>
 						<span style="font-size: 10px; margin: 0 5px 0 5px;"> </span>
 						<a class="open-advanced-settings" href="#" style="font-size: 10px; text-decoration: underline;">Advanced settings</a>
@@ -402,6 +404,42 @@
 					<br>
 					<p>
 						<a href="#" id="save-excludes"class="button button-lg">Save</a>
+					</p>
+			  </div>
+		 </article>
+		 <article id="lateral-api-fields" class="message is-warning" style="display:none;">
+			 <div class="message-header">
+					<nav class="level">
+						<div class="level-left">
+							<strong>Whitelist WP API fields</strong>
+						</div>
+						<div class="level-right">
+							<a href="#" class="close-api-fields" style="color:inherit"><i class="fa fa-times-circle" aria-hidden="true"></i></a>
+						</div>
+					</nav>
+			  </div>
+			  <div class="message-body">
+					<p><strong>Important:</strong> Add only one field per line.</p>
+					<br>
+					<p>
+						<?php
+							$wp_pwa_api_fields = $settings['wp_pwa_api_fields'];
+
+							$excludes_output = '';
+							for( $i=0; $i<count($wp_pwa_api_fields); $i++ ) {
+								$api_fields_output .= $wp_pwa_api_fields[$i];
+
+								if($i + 1 < (count($wp_pwa_api_fields))){
+									$api_fields_output .= "\n";
+								}
+							}
+						?>
+						<textarea id="api-fields" class="textarea"><?php echo $api_fields_output; ?></textarea>
+					</p>
+					<p><em>* Delete all fields to deactivate the whitelisting.</em></p>
+					<br>
+					<p>
+						<a href="#" id="save-api-fields"class="button button-lg">Save</a>
 					</p>
 			  </div>
 		 </article>

--- a/admin/wp-pwa-admin-page.php
+++ b/admin/wp-pwa-admin-page.php
@@ -411,7 +411,7 @@
 			 <div class="message-header">
 					<nav class="level">
 						<div class="level-left">
-							<strong>Whitelist WP API fields</strong>
+							<strong>Filter WP API fields</strong>
 						</div>
 						<div class="level-right">
 							<a href="#" class="close-api-fields" style="color:inherit"><i class="fa fa-times-circle" aria-hidden="true"></i></a>
@@ -436,7 +436,7 @@
 						?>
 						<textarea id="api-fields" class="textarea"><?php echo $api_fields_output; ?></textarea>
 					</p>
-					<p><em>* Delete all fields to deactivate the whitelisting.</em></p>
+					<p><em>* Use dot notation for nested fields (i.e: title.rendered).</em></p>
 					<br>
 					<p>
 						<a href="#" id="save-api-fields"class="button button-lg">Save</a>

--- a/libs/class-rest-api-filter-fields.php
+++ b/libs/class-rest-api-filter-fields.php
@@ -1,0 +1,249 @@
+<?php
+/**
+ * Code from the WP REST API Filter Fields plugin:
+ * 
+ * WP REST API - filter fields
+ *
+ * @package             REST_Api_Filter_Fields
+ * @author              Stephan van Rooij <github@svrooij.nl>
+ * @license             MIT
+ *
+ * @wordpress-plugin
+ * Plugin Name:         WP REST API - filter fields
+ * Plugin URI:          https://github.com/svrooij/rest-api-filter-fields
+ * Description:         Enables you to filter the fields returned by the api.
+ * Version:             1.0.7
+ * Author:              Stephan van Rooij
+ * Author URI:          https://svrooij.nl
+ * License:             MIT
+ * License URI:         https://raw.githubusercontent.com/svrooij/rest-api-filter-fields/master/LICENSE
+ */
+
+class REST_Api_Filter_Fields_Frontity {
+
+  public function __construct(){
+    add_action('rest_api_init',array($this,'init'),20);
+  }
+
+
+/**
+ * Register the fields functionality for all posts.
+ * Because of the 12 you can also use the filter functionality for custom posts
+ */
+public function init(){
+
+  // Get all public post types, default includes 'post','page','attachment' and custom types added before 'init', 20
+  $post_types = get_post_types(array('public' => true), 'objects');
+
+  foreach ($post_types as $post_type) {
+
+    //Test if this posttype should be shown in the rest api.
+    $show_in_rest = ( isset( $post_type->show_in_rest ) && $post_type->show_in_rest ) ? true : false;
+    if($show_in_rest) {
+
+      // We need the postname to enable the filter.
+      $post_type_name = $post_type->name;
+
+      //die($post_type_name);
+
+      // Add de filter. The api uses eg. 'rest_prepare_post' with 3 parameters.
+      add_filter('rest_prepare_'.$post_type_name,array($this,'filter_magic'),20,3);
+    }
+
+  }
+
+  $tax_types = get_taxonomies(array('public' => true), 'objects');
+
+  foreach ($tax_types as $tax_type) {
+
+    //Test if this posttype should be shown in the rest api.
+    $show_in_rest = ( isset( $tax_type->show_in_rest ) && $tax_type->show_in_rest ) ? true : false;
+    if($show_in_rest) {
+
+      // We need the postname to enable the filter.
+      $tax_type_name = $tax_type->name;
+
+      //die($post_type_name);
+
+      // Add de filter. The api uses eg. 'rest_prepare_post' with 3 parameters.
+      add_filter('rest_prepare_'.$tax_type_name,array($this,'filter_magic'),20,3);
+    }
+
+  }
+
+  // Also enable filtering 'categories', 'comments', 'taxonomies', 'terms' and 'users'
+  add_filter('rest_prepare_comment',array($this,'filter_magic'),20,3);
+  add_filter('rest_prepare_taxonomy',array($this,'filter_magic'),20,3);
+  add_filter('rest_prepare_term',array($this,'filter_magic'),20,3);
+  add_filter('rest_prepare_category',array($this,'filter_magic'),20,3);
+  add_filter('rest_prepare_user',array($this,'filter_magic'),20,3);
+}
+
+
+/**
+ * This is where the magic happends.
+ * @param WP_REST_Response   $response   The response object.
+ * @param WP_Post            $post       Post object.
+ * @param WP_REST_Request    $request    Request object.
+ * @return object (Either the original or the object with the fields filtered)
+ */
+public function filter_magic( $response, $post, $request ){
+  // Get the parameter from the WP_REST_Request
+  // This supports headers, GET/POST variables.
+  // and returns 'null' when not exists
+  $fields = $request->get_param('fields');
+  $embed = $request->get_param('_embed');
+  $settings = get_option('wp_pwa_settings');
+  $filters = isset($settings['wp_pwa_api_fields']) ? $settings['wp_pwa_api_fields'] : array();  
+
+  if(sizeof($filters) !== 0){
+
+    $filters[] = '_embedded';
+    // Create a new array
+    $filtered_data = array();
+
+    // The original data is in $response object in the property data
+    $data = $response->data;
+
+    // // If _embed is included in the GET also fetch the _embedded values.
+    if ($embed){
+      // Found in: https://core.trac.wordpress.org/browser/trunk/src/wp-includes/rest-api/endpoints/class-wp-rest-controller.php#L217
+      $rest_server = rest_get_server();
+      // Code from https://core.trac.wordpress.org/browser/trunk/src/wp-includes/rest-api/class-wp-rest-server.php#L382
+      // $result = $this->response_to_data( $result, isset( $_GET['_embed'] ) );
+      $data = $rest_server->response_to_data($response,true);
+    } else {
+      // The links should be included in the first place, so they can be filtered if needed.
+      $data['_links'] = $response->get_links();
+    }
+
+    // If the filter is empty return the original.
+    if(empty($filters) || count($filters) == 0)
+      return $response;
+
+    $singleFilters = array_filter($filters,array($this,'singleValueFilterArray'));
+
+    // Foreach property inside the data, check if the key is in the filter.
+    foreach ($data as $key => $value) {
+      // If the key is in the $filters array, add it to the $filtered_data
+      if (in_array($key, $singleFilters)) {
+        $filtered_data[$key] = $value;
+      }
+    }
+
+    $childFilters = array_filter($filters,array($this,'childValueFilterArray'));
+
+    // This part should be made better!!
+    foreach ($childFilters as $childFilter) {
+      $val = $this->array_path_value($data,$childFilter);
+      if($val != null){
+        $this->set_array_path_value($filtered_data,$childFilter,$val);
+      }
+    }
+
+  }
+
+  // return the filtered_data if it is set and got fields.
+  // return (isset($filtered_data) && count($filtered_data) > 0) ? rest_ensure_response($filtered_data) : $response;
+  if (isset($filtered_data) && count($filtered_data) > 0) {
+    //$filtered_data['_links'] = $response->get_links();
+    $newResp = rest_ensure_response($filtered_data);
+    return $newResp;
+  }
+
+  // return the response that we got in the first place.
+  return $response;
+}
+
+// Function to filter the fields array
+function singleValueFilterArray($var){
+  return (strpos($var,'.') ===false);
+}
+
+// Function to filter the fields array
+function childValueFilterArray($var){
+  return (strpos($var,'.') !=false);
+}
+
+// found on http://codeaid.net/php/get-values-of-multi-dimensional-arrays-using-xpath-notation
+function array_path_value(array $array, $path, $default = null)
+{
+    // specify the delimiter
+    $delimiter = '.';
+
+    // fail if the path is empty
+    if (empty($path)) {
+        throw new Exception('Path cannot be empty');
+    }
+
+    // remove all leading and trailing slashes
+    $path = trim($path, $delimiter);
+
+    // use current array as the initial value
+    $value = $array;
+
+    // extract parts of the path
+    $parts = explode($delimiter, $path);
+
+    // loop through each part and extract its value
+    foreach ($parts as $part) {
+        if (isset($value[$part])) {
+            // replace current value with the child
+            $value = $value[$part];
+        } elseif('first' == $part && is_array($value)){
+            $value = $value[0];
+        } else {
+            // key doesn't exist, fail
+            return $default;
+        }
+    }
+
+    return $value;
+}
+
+// Function found on http://codeaid.net/php/set-value-of-an-array-using-xpath-notation
+function set_array_path_value(array &$array, $path, $value)
+{
+    // fail if the path is empty
+    if (empty($path)) {
+        throw new Exception('Path cannot be empty');
+    }
+
+    // fail if path is not a string
+    if (!is_string($path)) {
+        throw new Exception('Path must be a string');
+    }
+
+    // specify the delimiter
+    $delimiter = '.';
+
+    // remove all leading and trailing slashes
+    $path = trim($path, $delimiter);
+
+    // split the path in into separate parts
+    $parts = explode($delimiter, $path);
+
+    // initially point to the root of the array
+    $pointer =& $array;
+
+    // loop through each part and ensure that the cell is there
+    foreach ($parts as $part) {
+        // fail if the part is empty
+        if (empty($part)) {
+            throw new Exception('Invalid path specified: ' . $path);
+        }
+
+        // create the cell if it doesn't exist
+        if (!isset($pointer[$part])) {
+            $pointer[$part] = array();
+        }
+
+        // redirect the pointer to the new cell
+        $pointer =& $pointer[$part];
+    }
+
+    // set value of the target cell
+    $pointer = $value;
+}
+}
+new REST_Api_Filter_Fields_Frontity();

--- a/libs/class-rest-api-filter-fields.php
+++ b/libs/class-rest-api-filter-fields.php
@@ -97,8 +97,6 @@ public function filter_magic( $response, $post, $request ){
   $filters = isset($settings['wp_pwa_api_fields']) ? $settings['wp_pwa_api_fields'] : array();  
 
   if(sizeof($filters) !== 0){
-
-    $filters[] = '_embedded';
     // Create a new array
     $filtered_data = array();
 
@@ -126,7 +124,7 @@ public function filter_magic( $response, $post, $request ){
     // Foreach property inside the data, check if the key is in the filter.
     foreach ($data as $key => $value) {
       // If the key is in the $filters array, add it to the $filtered_data
-      if (in_array($key, $singleFilters)) {
+      if (!in_array($key, $singleFilters)) {
         $filtered_data[$key] = $value;
       }
     }
@@ -137,7 +135,7 @@ public function filter_magic( $response, $post, $request ){
     foreach ($childFilters as $childFilter) {
       $val = $this->array_path_value($data,$childFilter);
       if($val != null){
-        $this->set_array_path_value($filtered_data,$childFilter,$val);
+        $this->unset_array_path_value($filtered_data,$childFilter,$val);
       }
     }
 
@@ -163,6 +161,20 @@ function singleValueFilterArray($var){
 // Function to filter the fields array
 function childValueFilterArray($var){
   return (strpos($var,'.') !=false);
+}
+
+function unset_array_path_value(&$array, $path) {
+  $path = explode('.', $path);
+  $temp = & $array;
+
+  foreach($path as $key) {
+      if(isset($temp[$key])){
+          if(!($key == end($path))) $temp = &$temp[$key];
+      } else {
+         return false; //invalid path
+      }
+  }
+  unset($temp[end($path)]);
 }
 
 // found on http://codeaid.net/php/get-values-of-multi-dimensional-arrays-using-xpath-notation

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "frontity-wp-plugin",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontity-wp-plugin",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "private": true,
   "description": "WordPress plugin to inject and configure » Frontity",
   "main": "index.js",

--- a/wp-pwa.php
+++ b/wp-pwa.php
@@ -59,6 +59,7 @@ class wp_pwa
 		add_action('wp_ajax_wp_pwa_change_siteid',array($this,'change_siteid_ajax'));
 		add_action('wp_ajax_wp_pwa_change_advanced_settings',array($this,'change_advanced_settings_ajax'));
 		add_action('wp_ajax_wp_pwa_save_excludes',array($this,'save_excludes_ajax'));
+		add_action('wp_ajax_wp_pwa_save_api_fields',array($this,'save_api_fields_ajax'));
 		add_action('wp_ajax_wp_pwa_purge_htmlpurifier_cache', array($this,'purge_htmlpurifier_cache'));
 
 		add_action('plugins_loaded', array($this,'wp_rest_api_plugin_is_installed'));
@@ -725,6 +726,24 @@ class wp_pwa
 		));
 	}
 
+	function save_api_fields_ajax() {
+		if ($_POST['wp_pwa_api_fields'] === '') {
+			$wp_pwa_api_fields = array();
+		} else {
+			$apiFields = stripslashes($_POST['wp_pwa_api_fields']);
+			$wp_pwa_api_fields = explode("\n", $apiFields);
+		}
+
+		$settings = get_option('wp_pwa_settings');
+		$settings['wp_pwa_api_fields'] = $wp_pwa_api_fields;
+
+		update_option('wp_pwa_settings', $settings);
+
+		wp_send_json( array(
+			'status' => 'ok',
+		));
+	}
+
 	//Checks if the rest-api plugin is installed
 	public function wp_rest_api_plugin_is_installed() {
 		if ( ! function_exists('get_plugins') ) {
@@ -863,6 +882,10 @@ function wp_pwa()
 	if( !isset($wp_pwa) )
 	{
 		$wp_pwa = new wp_pwa();
+	}
+	
+	if (class_exists( 'WP_REST_Controller')){
+		require_once('libs/class-rest-api-filter-fields.php');
 	}
 
 	$GLOBALS['wp_pwa_path'] = '/' . basename(plugin_dir_path( __FILE__ ));


### PR DESCRIPTION
Finally, the approach is to blacklist (filter) fields instead of whitelisting. Whitelisting may give us headaches in the future if we want to start supporting a new field which is not on everyone's whitelist.

Fixes #20.