### PR TITLE
fix(amp): don't include amphtml in attachments

### DIFF
--- a/includes/class-frontity-amp.php
+++ b/includes/class-frontity-amp.php
@@ -14,7 +14,7 @@ class Frontity_Amp
     $excluded = Frontity_Request::get('excluded');
 
     $this->should_inject = $amp_forced
-      || ($amp_active && is_single() && !$excluded);
+      || ($amp_active && is_single() && !is_attachment() && !$excluded);
   }
   
   // Generates the string with the AMP canonical link.


### PR DESCRIPTION
We don't support attachements, so the `amphtml` shouldn't be injected.